### PR TITLE
chore(python): switch to native namespaces

### DIFF
--- a/.github/workflows/plone-package-test.yml
+++ b/.github/workflows/plone-package-test.yml
@@ -14,6 +14,7 @@ jobs:
     with:
       check_path: |
         library/core
+      coverage_python_version: 3.12
       python_versions: '["3.12"]'
       runner_label: gha-runners-smartweb
       upload_to_coveralls: true

--- a/.github/workflows/plone-package-test.yml
+++ b/.github/workflows/plone-package-test.yml
@@ -14,6 +14,6 @@ jobs:
     with:
       check_path: |
         library/core
-      python_versions: '["3.12", "3.13"]'
+      python_versions: '["3.12"]'
       runner_label: gha-runners-smartweb
       upload_to_coveralls: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@ Changelog
 =========
 
 
-2.1.9 (unreleased)
+3.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Switch to PEP 420 native namespace package.
+  [remdub]
 
 
 2.1.8 (2026-07-07)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
         "Framework :: Plone :: Addon",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Installer for the library.core package."""
 
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 from setuptools import setup
 
 long_description = "\n\n".join(
@@ -25,9 +25,8 @@ setup(
         "Framework :: Plone :: 6.1",
         "Framework :: Plone :: Addon",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],
@@ -36,8 +35,7 @@ setup(
     author_email="support@imio.be",
     url="https://pypi.python.org/pypi/library.core",
     license="GPL version 2",
-    packages=find_packages("src", exclude=["ez_setup"]),
-    namespace_packages=["library"],
+    packages=find_namespace_packages("src", exclude=["ez_setup"]),
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,

--- a/src/library/__init__.py
+++ b/src/library/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated packaging to use native namespace packages (PEP 420).
  * Adjusted supported Python versions to 3.12 only.
* **Documentation**
  * Updated the changelog to start a new unreleased 3.0.0 section.
* **Tests**
  * Updated CI test coverage to run only on Python 3.12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->